### PR TITLE
Feat/kakao login

### DIFF
--- a/src/api/pungApi.js
+++ b/src/api/pungApi.js
@@ -14,10 +14,6 @@ export const fetchPungs = async (placeId, page) => {
 };
 
 export const addPung = async (userId, placeId, imageWithText, pureImage, text) => {
-  // 액세스토큰 로컬스토리지에 임시 저장
-  // const accessToken = ;
-  // localStorage.setItem('accessToken', accessToken);
-
   const data = new FormData();
 
   data.append('userId', userId);

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -91,7 +91,6 @@ const Map = () => {
 
   // bounds 변경 시 카페 목록 다시 가져오기
   useEffect(() => {
-    console.log('bounds changed');
     if (bounds) {
       const sw = bounds.getSouthWest();
       const ne = bounds.getNorthEast();

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -4,12 +4,13 @@ import styled from 'styled-components';
 import kakaoLoginImage from '../assets/images/kakao_login_medium_narrow.png';
 
 const Login = () => {
+  const { setShowMap } = useStore();
+
+  //console.log('accessToken', accessToken);
   const handleLogin = () => {
     // 백엔드 OAuth2 인증 엔드포인트로 리다이렉트
     window.location.href = `${process.env.REACT_APP_API_URL}/oauth2/authorization/kakao`;
   };
-
-  const { setShowMap } = useStore();
 
   useEffect(() => {
     // 페이지 로드 시 맵 숨기기
@@ -24,7 +25,7 @@ const Login = () => {
   return (
     <Wrapper>
       <h2>로그인이 필요합니다.</h2>
-      <img src={kakaoLoginImage} onClick={handleLogin} />
+      <img src={kakaoLoginImage} alt="카카오 로그인" onClick={handleLogin} />
     </Wrapper>
   );
 };

--- a/src/pages/OAuthCallback.js
+++ b/src/pages/OAuthCallback.js
@@ -19,8 +19,9 @@ const OAuthCallback = () => {
         const userName = params.get('userName');
         const userEmail = params.get('userEmail');
 
-        if (status === 'success' && token && userId && userName && userEmail) {
+        if (status === 'success' && token) {
           setAccessToken(token);
+          localStorage.setItem('accessToken', token);
           setUserInfo({
             userId,
             userName,

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 const API_URL = `${process.env.REACT_APP_API_URL}`;
 
 const Profile = () => {
-  const { isAuthenticated, clearAuth } = useAuthStore();
+  const { accessToken, clearAuth } = useAuthStore();
   const { setShowMap } = useStore();
 
   useEffect(() => {
@@ -14,7 +14,7 @@ const Profile = () => {
     setShowMap(false);
 
     // 인증되지 않은 경우 로그인 리다이렉트
-    if (!isAuthenticated) {
+    if (!accessToken) {
       window.location.href = `${API_URL}/oauth2/authorization/kakao`;
       return;
     }
@@ -23,7 +23,7 @@ const Profile = () => {
     return () => {
       setShowMap(true);
     };
-  }, [isAuthenticated, setShowMap]);
+  }, [accessToken, setShowMap]);
 
   const handleLogout = () => {
     //window.location.href = `${API_URL}/logout`;

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -1,13 +1,21 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
-const useAuthStore = create((set) => ({
-  accessToken: null,
-  userInfo: null,
-  isAuthenticated: false,
+const useAuthStore = create(
+  persist(
+    (set) => ({
+      accessToken: null,
+      userInfo: null,
 
-  setAccessToken: (token) => set({ accessToken: token, isAuthenticated: !!token }),
-  setUserInfo: (userInfo) => set({ userInfo }),
-  clearAuth: () => set({ accessToken: null, userInfo: null, isAuthenticated: false }),
-}));
+      setAccessToken: (token) => set({ accessToken: token, isAuthenticated: !!token }),
+      setUserInfo: (userInfo) => set({ userInfo }),
+      clearAuth: () => set({ accessToken: null, userInfo: null, isAuthenticated: false }),
+    }),
+    {
+      name: 'auth-storage',
+      getStorage: () => localStorage,
+    },
+  ),
+);
 
 export default useAuthStore;


### PR DESCRIPTION
새로고침시 로그인상태 초기화되는 에러 해결
isAuthenticated 버리고 accessToken으로 해결 -> 이제 리프레시 로직 api 받으면 그거 추가하고 401로 토큰새로 받아오는거 판단하게 바꿔야함